### PR TITLE
fix: Ceiling BlockFamily compatibility

### DIFF
--- a/src/main/java/org/terasology/furnishings/logic/door/DoorSystem.java
+++ b/src/main/java/org/terasology/furnishings/logic/door/DoorSystem.java
@@ -30,6 +30,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
@@ -118,8 +119,9 @@ public class DoorSystem extends BaseComponentSystem {
             closedSide = attachSide.yawClockwise(1);
         }
 
-        Block newBottomBlock = door.bottomBlockFamily.getBlockForPlacement(bottomBlockPos, closedSide, Side.TOP);
-        Block newTopBlock = door.topBlockFamily.getBlockForPlacement(bottomBlockPos, closedSide, Side.TOP);
+        org.joml.Vector3f viewingDirection = JomlUtil.from(event.getDirection());
+        Block newBottomBlock = door.bottomBlockFamily.getBlockForPlacement(bottomBlockPos, closedSide, viewingDirection);
+        Block newTopBlock = door.topBlockFamily.getBlockForPlacement(bottomBlockPos, closedSide, viewingDirection);
 
         Map<Vector3i, Block> blockMap = new HashMap<>();
         blockMap.put(bottomBlockPos, newBottomBlock);
@@ -191,9 +193,10 @@ public class DoorSystem extends BaseComponentSystem {
         DoorComponent door = entity.getComponent(DoorComponent.class);
         Side newSide = door.closedSide;
         BlockRegionComponent regionComp = entity.getComponent(BlockRegionComponent.class);
-        Block bottomBlock = door.bottomBlockFamily.getBlockForPlacement(regionComp.region.min(), newSide, Side.TOP);
+        org.joml.Vector3f forward = new org.joml.Vector3f(0, 0, 1);
+        Block bottomBlock = door.bottomBlockFamily.getBlockForPlacement(regionComp.region.min(), newSide, forward);
         worldProvider.setBlock(regionComp.region.min(), bottomBlock);
-        Block topBlock = door.topBlockFamily.getBlockForPlacement(regionComp.region.max(), newSide, Side.TOP);
+        Block topBlock = door.topBlockFamily.getBlockForPlacement(regionComp.region.max(), newSide, forward);
         worldProvider.setBlock(regionComp.region.max(), topBlock);
         if (door.closeSound != null) {
             entity.send(new PlaySoundEvent(door.closeSound, 1f));
@@ -208,9 +211,10 @@ public class DoorSystem extends BaseComponentSystem {
         DoorComponent door = entity.getComponent(DoorComponent.class);
         Side newSide = door.openSide;
         BlockRegionComponent regionComp = entity.getComponent(BlockRegionComponent.class);
-        Block bottomBlock = door.bottomBlockFamily.getBlockForPlacement(regionComp.region.min(), newSide, Side.TOP);
+        org.joml.Vector3f forward = new org.joml.Vector3f(0, 0, 1);
+        Block bottomBlock = door.bottomBlockFamily.getBlockForPlacement(regionComp.region.min(), newSide, forward);
         worldProvider.setBlock(regionComp.region.min(), bottomBlock);
-        Block topBlock = door.topBlockFamily.getBlockForPlacement(regionComp.region.max(), newSide, Side.TOP);
+        Block topBlock = door.topBlockFamily.getBlockForPlacement(regionComp.region.max(), newSide, forward);
         worldProvider.setBlock(regionComp.region.max(), topBlock);
         if (door.openSound != null) {
             entity.send(new PlaySoundEvent(door.openSound, 1f));

--- a/src/main/java/org/terasology/furnishings/logic/trunk/TrunkSystem.java
+++ b/src/main/java/org/terasology/furnishings/logic/trunk/TrunkSystem.java
@@ -30,6 +30,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.inventory.ItemComponent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.Region3i;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3f;
@@ -121,12 +122,14 @@ public class TrunkSystem extends BaseComponentSystem {
         Block newBottomBlock;
         Block newTopBlock;
 
+        org.joml.Vector3f viewingDirection = JomlUtil.from(event.getDirection());
+
         if (facingDir == Side.FRONT || facingDir == Side.RIGHT) {
-            newBottomBlock = trunk.rightBlockFamily.getBlockForPlacement(leftBlockPos, Side.BOTTOM, facingDir.reverse());
-            newTopBlock = trunk.leftBlockFamily.getBlockForPlacement(rightBlockPos, Side.BOTTOM, facingDir.reverse());
+            newBottomBlock = trunk.rightBlockFamily.getBlockForPlacement(leftBlockPos, Side.BOTTOM, viewingDirection);
+            newTopBlock = trunk.leftBlockFamily.getBlockForPlacement(rightBlockPos, Side.BOTTOM, viewingDirection);
         } else {
-            newBottomBlock = trunk.leftBlockFamily.getBlockForPlacement(leftBlockPos, Side.BOTTOM, facingDir.reverse());
-            newTopBlock = trunk.rightBlockFamily.getBlockForPlacement(rightBlockPos, Side.BOTTOM, facingDir.reverse());
+            newBottomBlock = trunk.leftBlockFamily.getBlockForPlacement(leftBlockPos, Side.BOTTOM, viewingDirection);
+            newTopBlock = trunk.rightBlockFamily.getBlockForPlacement(rightBlockPos, Side.BOTTOM, viewingDirection);
         }
         Map<Vector3i, Block> blockMap = new HashMap<>();
         blockMap.put(leftBlockPos, newBottomBlock);


### PR DESCRIPTION
This PR fixes the module's compatibility with the changes introduced in this Terasology PR: [#3978](https://github.com/MovingBlocks/Terasology/pull/3978).

### Test
Add trunks to your inventory using `give trunk 10` and attach them to different block sides.
Verify that their placement behavior is unchanged.